### PR TITLE
Uppercase/mixedcase tag support for walk() function [new]

### DIFF
--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -70,7 +70,7 @@ function walk(dom, options) {
 	_.each(dom, function(elem) {
 		switch(elem.type) {
 			case 'tag':
-				switch(elem.name) {
+				switch(elem.name.toLowerCase()) {
 					case 'a':
 						result += format.anchor(elem, walk, options);
 						break;


### PR DESCRIPTION
Lowercasing encountered element names to walk `<A>`, `<P>`, `<TaBLe>`, etc. in walk()'s tag switch block
