### PR TITLE
Empty ordered lists cause a crash

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -66,15 +66,18 @@ function formatUnorderedList(elem, fn, options) {
 
 function formatOrderedList(elem, fn, options) {
 	var result = '';
-	// Calculate the maximum length to i.
-	var maxLength = elem.children.length.toString().length;
-	_.each(elem.children, function(elem, i) {
-		var index = i + 1;
-		// Calculate the needed spacing for nice indentation.
-		var spacing = maxLength - index.toString().length;
-		var prefix = ' ' + index + '. ' + _s.repeat(' ', spacing);
-		result += formatListItem(prefix, elem, fn, options);
-	});
+	// Make sure there are list items present
++	if (elem.children && elem.children.length) {
+		// Calculate the maximum length to i.
+		var maxLength = elem.children.length.toString().length;
+		_.each(elem.children, function(elem, i) {
+			var index = i + 1;
+			// Calculate the needed spacing for nice indentation.
+			var spacing = maxLength - index.toString().length;
+			var prefix = ' ' + index + '. ' + _s.repeat(' ', spacing);
+			result += formatListItem(prefix, elem, fn, options);
+		});
+	}
 	return result + '\n';
 };
 


### PR DESCRIPTION
When formatting ordered lists the code tries to query `elem.children.length` before checking to make sure that `elem.children` exists, which it doesn't if there are none present.

This fixes that.  I tried to keep the formatting and comment style consistent.

Avi
