### PR TITLE
Added support for custom callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 .DS_Store
 node_modules

--- a/example/html-to-text.js
+++ b/example/html-to-text.js
@@ -2,17 +2,39 @@ var path = require('path');
 
 var htmlToText = require('../lib/html-to-text');
 
-console.log('fromString:')
+console.log('fromString:');
 var text = htmlToText.fromString('<h1>Hello World</h1>', {
 	wordwrap: 130
 });
 console.log(text);
 console.log();
 
-console.log('fromFile:');
 htmlToText.fromFile(path.join(__dirname, 'test.html'), {
 	tables: ['#invoice', '.address']
 }, function(err, text) {
 	if (err) return console.error(err);
+	console.log('fromFile:');
 	console.log(text);
+	console.log();
 });
+
+htmlToText.fromFile(
+	path.join(__dirname, 'test-custom.html'),
+	{
+		tables: ['#tabular_data'],
+		custom: function (elem) {
+			if (elem.type === 'tag' && elem.name === 'img' && elem.attribs['alt'] === 'graph') {
+				return "To see the graph, visit here: http://my-site.com/reports/graph";
+			}
+			if (elem.type === 'tag' && elem.name === 'table' && elem.attribs['id'] === 'tabular_data') {
+				return ["(For best results, please see the HTML version, or visit our site)\n", true];
+			}
+		}
+	},
+	function(err, text) {
+		if (err) return console.error(err);
+		console.log('custom:');
+		console.log(text);
+		console.log();
+	}
+);

--- a/example/test-custom.html
+++ b/example/test-custom.html
@@ -1,0 +1,32 @@
+<html>
+	<head>
+		<meta charset="utf-8">
+	</head>
+	<body>
+		<h1>Monthly report</h1>
+
+		<h3>Trends over the previous month:</h3>
+		<p>
+			<img href="http://my-site.com/assets/graph.png" alt="graph" />
+		</p>
+
+		<h3>Tabular data</h3>
+		<table cellpadding="0" cellspacing="0" border="1" id="tabular_data">
+				<tr>
+					<th>Id</th>
+					<th>Name</th>
+					<th>Amount</th>
+				</tr>
+				<tr>
+					<td>12542</td>
+					<td>Widgets</td>
+					<td>232</td>
+				</tr>
+				<tr>
+					<td>15121</td>
+					<td>Sprockets</td>
+					<td>115</td>
+				</tr>
+		</table>
+	</body>
+</html>

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -18,7 +18,8 @@ function htmlToText(html, options) {
 	options = options || {};
 	_.defaults(options, {
 		wordwrap: 80,
-		tables: []
+		tables: [],
+		custom: false
 	});
 
 	var handler = new htmlparser.DefaultHandler(function (error, dom) {
@@ -74,7 +75,24 @@ function containsTable(attr, tables) {
 function walk(dom, options) {
 	var result = '';
 	var whiteSpaceRegex = /\S$/;
+	var customResult;
 	_.each(dom, function(elem) {
+		if (options.custom) {
+			customResult = options.custom(elem, options);
+			if (_.isString(customResult)) {
+				result += customResult;
+				return;
+			}
+			if (customResult === false) {
+				return;
+			}
+			if (_.isArray(customResult)) {
+				result += customResult[0];
+				if (customResult[1] === false) {
+					return;
+				}
+			}
+		}
 		switch(elem.type) {
 			case 'tag':
 				switch(elem.name.toLowerCase()) {


### PR DESCRIPTION
The ability to add a "custom" element handler in the options.

``` javascript
var options = {
  custom: function (elem, options) {
    if (elem.type === 'tag') {
      return "fizz\n";
    }
    if (elem.type === 'text') {
      return "buzz\n";
    }
  }
};
```

Custom functions takes the current element and options. It can return one of 3 things:
- `"string"`: It is appended to the `result`. No default processing.
- `false`: No default processing, element is skipped.
- `["string", false/true]`: First element is appended to the result. Second element allows/disallows default processing. Useful if we want to append some text and then proceed as usual (see example).

I also included an example where I demonstrate 2 use cases (this will hopefully be converted to unit tests at some point).

Also:
- I added .idea to `.gitignore` (this is for my IDE, you can revert it if you wish, but it doesn't hurt IMO)
- A few minor fixes in the demo code
