### PR TITLE
Enable to Remove tag-s and provide replacement text instead in output text.

### DIFF
--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -11,12 +11,12 @@ var format = require('./formatter');
 // Which type of tags should not be parsed
 var SKIP_TYPES = [
 	'style',
-	'script',
-	'table'
+	'script'
 ];
 
 function htmlToText(html, options) {
 	options = options || {};
+	console.log("*** Options 1: " + JSON.stringify(options));
 	_.defaults(options, {
 		wordwrap: 80,
 		tables: [],
@@ -33,8 +33,10 @@ function htmlToText(html, options) {
 		longWordSplit: {
 			wrapCharacters: [],
 			forceWrapOnLimit: false
-		}
+		},
+		skipTags: null
 	});
+	console.log("*** Options 2: " + JSON.stringify(options));
 
 	var handler = new htmlparser.DefaultHandler(function (error, dom) {
 
@@ -109,6 +111,17 @@ function walk(dom, options, result) {
 	_.each(dom, function(elem) {
 		switch(elem.type) {
 			case 'tag':
+				if (elem.name && options.skipTags) {
+					if (typeof options.skipTags === "function") {
+						var skip = options.skipTags(elem);
+						if (skip) {
+							if (typeof skip === 'object' && skip.replacement) {
+								result += skip.replacement;
+							}
+							break;
+						}
+					}
+				}
 				switch(elem.name.toLowerCase()) {
 					case 'img':
 						result += format.image(elem, options);

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -200,3 +200,5 @@ exports.fromFile = function(file, options, callback) {
 exports.fromString = function(str, options) {
 	return htmlToText(str, options || {});
 };
+
+exports.walk = walk;

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -16,7 +16,6 @@ var SKIP_TYPES = [
 
 function htmlToText(html, options) {
 	options = options || {};
-	console.log("*** Options 1: " + JSON.stringify(options));
 	_.defaults(options, {
 		wordwrap: 80,
 		tables: [],
@@ -36,7 +35,6 @@ function htmlToText(html, options) {
 		},
 		skipTags: null
 	});
-	console.log("*** Options 2: " + JSON.stringify(options));
 
 	var handler = new htmlparser.DefaultHandler(function (error, dom) {
 

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -11,7 +11,8 @@ var format = require('./formatter');
 // Which type of tags should not be parsed
 var SKIP_TYPES = [
 	'style',
-	'script'
+	'script',
+	'table'
 ];
 
 function htmlToText(html, options) {


### PR DESCRIPTION
Hello.

With this pull request one can provide a function with options (options.skipTags = <function>) to remove tag-s from resulting text (and / or provide a replacement text aloing with it).

Jaanek
