### PR TITLE
div formatter, bugfix for preserveNewlines option, handle empty block level elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can configure the behaviour of html-to-text with the following options:
 
 ### Override formatting for specific elements
 
-By using the `format` option, you can specify formatting for these elements: `text`, `image`, `lineBreak`, `paragraph`, `anchor`, `heading`, `table`, `orderedList`, `unorderedList`, `listItem`, `horizontalLine`.
+By using the `format` option, you can specify formatting for these elements: `text`, `image`, `lineBreak`, `paragraph`, `anchor`, `heading`, `table`, `orderedList`, `unorderedList`, `listItem`, `horizontalLine`, `div`.
 
 Each key must be a function which eventually receive `node` (the current node), `fn` (the next formatting function) and `options` (the options passed to html-to-text).
 

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -39,7 +39,9 @@ function formatLineBreak(elem, fn, options) {
 
 function formatParagraph(elem, fn, options) {
   var paragraph = fn(elem.children, options)
-  if (options.singleNewLineParagraphs) {
+  if (paragraph.trim().length === 0) {
+    return paragraph;
+  } else if (options.singleNewLineParagraphs) {
     return paragraph + '\n'
   } else {
     return paragraph + '\n\n'
@@ -48,12 +50,17 @@ function formatParagraph(elem, fn, options) {
 
 function formatDiv(elem, fn, options) {
   var divContent = fn(elem.children, options)
+  if (divContent.trim().length === 0) {
+    return divContent;
+  }
   return divContent + '\n'
 }
 
 function formatHeading(elem, fn, options) {
   var heading = fn(elem.children, options);
-  if (options.uppercaseHeadings) {
+  if (heading.trim().length === 0) {
+    return heading;
+  } else if (options.uppercaseHeadings) {
     heading = heading.toUpperCase();
   }
   return heading + '\n';

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -46,6 +46,11 @@ function formatParagraph(elem, fn, options) {
   }
 }
 
+function formatDiv(elem, fn, options) {
+  var divContent = fn(elem.children, options)
+  return divContent + '\n'
+}
+
 function formatHeading(elem, fn, options) {
   var heading = fn(elem.children, options);
   if (options.uppercaseHeadings) {
@@ -255,3 +260,4 @@ exports.orderedList = formatOrderedList;
 exports.unorderedList = formatUnorderedList;
 exports.listItem = formatListItem;
 exports.horizontalLine = formatHorizontalLine;
+exports.div = formatDiv;

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -102,7 +102,7 @@ exports.wordwrap = function wordwrap(text, options) {
 
   // Preserve trailing space
   if (!_s.endsWith(text, ' ')) {
-    result = _s.rtrim(result);
+    result = _s.rtrim(result, preserveNewlines ? '[ \t\f\uFEFF\xA0]' : null);
   } else if (!_s.endsWith(result, ' ')) {
     result = result + ' ';
   }

--- a/lib/html-to-text.js
+++ b/lib/html-to-text.js
@@ -124,6 +124,9 @@ function walk(dom, options, result) {
             elem.trimLeadingSpace = whiteSpaceRegex.test(result);
             result += format.anchor(elem, walk, options);
             break;
+          case 'div':
+            result += format.div(elem, walk, options);
+            break;
           case 'p':
             result += format.paragraph(elem, walk, options);
             break;


### PR DESCRIPTION
1. formatter for div element (fix #71)
2. bugfix for preserveNewlines option where trailing line breaks could be trimmed
3. for block level elements, not to add a line break when it's empty