### PR TITLE
handle colspan on table headers

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -210,16 +210,15 @@ function formatTable(elem, fn, options) {
       case 'tr':
         var rows = [];
         _.each(elem.children, function(elem) {
-          var tokens, times;
+          var tokens, times, name;
           if (elem.type === 'tag') {
-            switch (elem.name.toLowerCase()) {
+            name = elem.name.toLowerCase()
+            switch (name) {
               case 'th':
-                tokens = formatHeading(elem, fn, options).split('\n');
-                rows.push(_.compact(tokens));
-                break;
-
               case 'td':
-                tokens = fn(elem.children, options).split('\n');
+                tokens = name === 'th'
+                  ? formatHeading(elem, fn, options).split('\n')
+                  : fn(elem.children, options).split('\n');
                 rows.push(_.compact(tokens));
                 // Fill colspans with empty values
                 if (elem.attribs && elem.attribs.colspan) {


### PR DESCRIPTION
This change fixes an issue where the table formatter currently ignores `colspan` attributes on `th` tags. For example:
![image](https://user-images.githubusercontent.com/2843237/31135562-610d6f8a-a833-11e7-9ff3-9c64b74bb314.png)

with this markup:

```
<table class="capitalization" summary="Capitalization Examples">
  <caption> Headline Capitalization </caption>
  <colgroup>
    <col style="width:15%">
      <col style="width:15%">
  </colgroup>
  <colgroup>
    <col style="width:10%">
      <col style="width:30%">
        <col style="width:30%">
  </colgroup>
  <thead>
    <tr style="background-color:#ddd">
      <th class="tableheader" colspan="2">Capitalize</th>
      <th class="tableheader" colspan="3">lowercase</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td> <i>No <br>    Nor <br>    Not</i> </td>
      <td> <i>Off <br>    Out <br>    So <br>    Up</i> </td>
      <td> <i>a <br>    and <br>    as <br>    at <br>    but <br>    by</i> </td>
      <td> <i>en</i> (in <i>en Route</i>)
        <br><i>for <br>    if <br>    in <br>    of <br>    on</i> </td>
      <td> <i>or</i>
        <br><i>the</i>
        <br><i>to</i>
        <br><i>v.</i> (in legal contexts)
        <br><i>vs. <br>    via</i> </td>
    </tr>
  </tbody>
</table>
```

Results in this text:
```
CAPITALIZE   LOWERCASE   
No           Off         a      en (in en Route)     or                        
Nor          Out         and    for                  the                       
Not          So          as     if                   to                        
             Up          at     in                   v. (in legal contexts)    
                         but    of                   vs.                       
                         by     on                   via
```

When really what should be output is _this_ text:
```
CAPITALIZE           LOWERCASE                                                  
No           Off     a           en (in en Route)     or                        
Nor          Out     and         for                  the                       
Not          So      as          if                   to                        
             Up      at          in                   v. (in legal contexts)    
                     but         of                   vs.                       
                     by          on                   via
```

This change does not attempt to fix the absence of the `<caption>` tag's content from the output text, which is also demonstrated by the above markup.