### PR TITLE
Fixing &nbsp; conversion to whitespace. Test included.

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -13,6 +13,9 @@ function formatText(elem, options) {
   var text = elem.data || "";
   text = he.decode(text, options.decodeOptions);
 
+  // Converting &nbsp; to regular whitespace so that it does not get trimmed out in helper.js
+  text = text.replace(/\u00a0/g, ' ');
+
   if (options.isInPre) {
     return text;
   } else {

--- a/test/html-to-text.js
+++ b/test/html-to-text.js
@@ -595,6 +595,11 @@ describe('html-to-text', function() {
       var testString = 'foo<span> </span>bar';
       expect(htmlToText.fromString(testString)).to.equal('foo bar');
     });
+
+    it('should treat &nbsp; as a whitespace', function() {
+      var testString = 'foo<span>&nbsp;</span>bar';
+      expect(htmlToText.fromString(testString)).to.equal('foo bar');
+    });
   });
 
   describe('wbr', function() {

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -1,0 +1,98 @@
+var expect = require('chai').expect;
+var fs = require('fs');
+
+var exec = require('child_process').exec;
+
+function runWithInputAndExpect(input, args, expectedOutput, done) {
+  exec('echo "' + input.replace(/"/g, '\\"') + '" | node bin/cli.js ' + args, function callback(error, stdout, stderr) {
+    expect(error).to.be.a('null');
+    expect(stderr).to.equal('');
+    expect(stdout).to.equal(expectedOutput + '\n');
+    done(error);
+  });
+}
+
+describe('cli arguments', function() {
+  it('should output nothing with empty input', function(done) {
+    runWithInputAndExpect('', '', '', done);
+  });
+
+  it('should not ignore images by default', function (done) {
+    runWithInputAndExpect(
+      'Hello <img alt="alt text" src="http://my.img/here.jpg">!',
+      '',
+      'Hello alt text [http://my.img/here.jpg]!',
+      done);
+  });
+
+  it('should ignore images with --ignore-image=true', function (done) {
+    runWithInputAndExpect(
+      'Hello <img alt="alt text" src="http://my.img/here.jpg">!',
+      '--ignore-image=true',
+      'Hello !',
+      done);
+  });
+
+  it('should not ignore href by default', function (done) {
+    runWithInputAndExpect(
+      '<a href="http://my.link">test</a>',
+      '',
+      'test [http://my.link]',
+      done);
+  });
+
+  it('should ignore href with --ignore-href=true', function (done) {
+    runWithInputAndExpect(
+      '<a href="http://my.link">test</a>',
+      '--ignore-href=true',
+      'test',
+      done);
+  });
+
+  it('should wordwrap at 80 characters by default', function (done) {
+    runWithInputAndExpect(
+      ' 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789',
+      '',
+      ' 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789\n123456789',
+      done);
+  });
+
+  it('should wordwrap at 40 with --wordwrap=40', function (done) {
+    runWithInputAndExpect(
+      ' 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789 123456789',
+      '--wordwrap=40',
+      ' 123456789 123456789 123456789 123456789\n123456789 123456789 123456789 123456789\n123456789',
+      done);
+  });
+
+  it('should return link with brackets by default', function (done) {
+    runWithInputAndExpect(
+      '<a href="http://my.link">test</a>',
+      '',
+      'test [http://my.link]',
+      done);
+  });
+
+  it('should return link without brackets with --noLinkBrackets=true', function (done) {
+    runWithInputAndExpect(
+      '<a href="http://my.link">test</a>',
+      '--noLinkBrackets=true',
+      'test http://my.link',
+      done);
+  });
+
+  it('should support --tables definitions with commas', function(done) {
+    var expectedTxt = fs.readFileSync('test/test.txt', 'utf8');
+
+    function runWithArgs(args, callback) {
+      exec('cat test/test.html | node bin/cli.js ' + args, callback);
+    }
+
+    runWithArgs('--tables=#invoice,.address', function callback(error, stdout, stderr) {
+      expect(error).to.be.a('null');
+      expect(stderr).to.equal('');
+      expect(stdout).to.equal(expectedTxt + '\n');
+      done(error);
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes the problems with `&nbsp;` getting trimmed out. A testcase is included.

Previously _foo&lt;span&gt;&nbsp&lt;/span&gt;bar_ was being converted to _foobar_. Now it will be converted to _foo bar_.

As seen in #107 there are issues with `nbsp;` getting lost in the transforms. Many of these seem to be caused by inconsistent whitespace checks in `helpers.js` There are are calls to `String.startsWith(' ')`, `String.endsWith(' ')`, `String.trim()` and `lodash.trimEnd()`- many of which treat whitespace characters differently. Thus `nbsp;` had to be converted to a regular whitespace before the processing gets too far. This is being done with a regexp matching the unicode entry for non-breaking-space.