### PR TITLE
fix: updated formatUnorderedList to support empty itemPrefix

### DIFF
--- a/packages/html-to-text/src/text-formatters.js
+++ b/packages/html-to-text/src/text-formatters.js
@@ -231,7 +231,7 @@ function formatList (elem, walk, builder, formatOptions, nextPrefixCallback) {
  * @type { FormatCallback }
  */
 function formatUnorderedList (elem, walk, builder, formatOptions) {
-  const prefix = formatOptions.itemPrefix || ' * ';
+  const prefix = (typeof formatOptions.itemPrefix === 'string') ? formatOptions.itemPrefix : ' * ';
   return formatList(elem, walk, builder, formatOptions, () => prefix);
 }
 

--- a/packages/html-to-text/test/tags.js
+++ b/packages/html-to-text/test/tags.js
@@ -427,6 +427,17 @@ describe('tags', function () {
         expect(htmlToText(html, options)).to.equal(expected);
       });
 
+      it('should handle an unordered list with an empty prefix option', function () {
+        const html = '<ul><li>foo</li><li>bar</li></ul>';
+        const options = {
+          selectors: [
+            { selector: 'ul', options: { itemPrefix: '' } }
+          ]
+        };
+        const expected = 'foo\nbar';
+        expect(htmlToText(html, options)).to.equal(expected);
+      });
+
       it('should handle nested ul correctly', function () {
         const html = /*html*/`<ul><li>foo<ul><li>bar<ul><li>baz.1</li><li>baz.2</li></ul></li></ul></li></ul>`;
         const expected = ' * foo\n   * bar\n     * baz.1\n     * baz.2';


### PR DESCRIPTION
Currently if you specify an empty string as an unordered list item prefix it will ignore it because empty string is falsy. I have updated the formatUnorderedList to support empty strings so that if you don't want an item prefix you can just set it to an empty string.
